### PR TITLE
Ability to pass few modifiers per one class

### DIFF
--- a/index.js
+++ b/index.js
@@ -14,7 +14,6 @@ module.exports = function(settings) {
   settings.few_modifiers_per_class = settings.few_modifiers_per_class || false;
 
   return function(buf, bem_chain, bem_chain_contexts, tag, isElement) {
-    //console.log("-->", arguments);
     var block = this.block;
     var attributes = this.attributes || {};
 
@@ -29,7 +28,6 @@ module.exports = function(settings) {
 
       classes = classes.split(' ');
 
-      console.log(settings.few_modifiers_per_class);
       if (settings.few_modifiers_per_class) {
         classes.map(function(cls) {
           tokens = cls.match(new RegExp('.+?(?=' + settings.modifier + '|$)', 'gi'));

--- a/index.js
+++ b/index.js
@@ -11,6 +11,7 @@ module.exports = function(settings) {
   settings.element = settings.element || '__';
   settings.modifier = settings.modifier || '_';
   settings.default_tag = settings.default_tag || 'div';
+  settings.few_modifiers_per_class = settings.few_modifiers_per_class || false;
 
   return function(buf, bem_chain, bem_chain_contexts, tag, isElement) {
     //console.log("-->", arguments);
@@ -19,12 +20,24 @@ module.exports = function(settings) {
 
     // Rewriting the class for elements and modifiers
     if (attributes.class) {
-      var bem_classes = attributes.class;
+      var classes = attributes.class;
+      var bem_classes = [];
 
-      if (bem_classes instanceof Array) {
-        bem_classes = bem_classes.join(' ');
+      if (classes instanceof Array) {
+        classes = classes.join(' ');
       }
-      bem_classes = bem_classes.split(' ');
+
+      classes = classes.split(' ');
+
+      console.log(settings.few_modifiers_per_class);
+      if (settings.few_modifiers_per_class) {
+        classes.map(function(cls) {
+          tokens = cls.match(new RegExp('.+?(?=' + settings.modifier + '|$)', 'gi'));
+          bem_classes.push.apply(bem_classes, tokens);
+        })
+      } else {
+        bem_classes = classes;
+      }
 
       var bem_block;
       try {
@@ -96,7 +109,7 @@ module.exports = function(settings) {
       } else if (bem_chain_contexts[contextIndex - 1] === 'list') {
         newTag = 'li';
       }
-      
+
 
       //Attributes context checks
       if (attributes.href) {

--- a/test/cases/5_complex.jade
+++ b/test/cases/5_complex.jade
@@ -1,7 +1,7 @@
 include ../../bem
 
 mixin link(url)
-  +b('span').link(href=url)&attributes(attributes)
+  +b.link(href=url)&attributes(attributes)
     block
 
 p
@@ -14,7 +14,7 @@ p
   +link('http://kizu.ru').url(rel="me") Here I am
 
 p
-  +link Ah, I'm not a link
+  +b('span').link Ah, I'm not a link
 
 p
   +link('https://github.com')

--- a/test/cases/7_few_modifiers.html
+++ b/test/cases/7_few_modifiers.html
@@ -1,0 +1,1 @@
+<div class="block block--modifier-name block--other-modifier">foo</div>

--- a/test/cases/7_few_modifiers.jade
+++ b/test/cases/7_few_modifiers.jade
@@ -1,0 +1,4 @@
+include ../../bem
+
++b.block--modifier-name--other-modifier
+  | foo

--- a/test/cases/7_few_modifiers.settings.json
+++ b/test/cases/7_few_modifiers.settings.json
@@ -1,0 +1,8 @@
+{
+  "prefix": "",
+  "element": "__",
+  "modifier": "--",
+  "few_modifiers_per_class": true
+}
+
+


### PR DESCRIPTION
In our team we use `--` as modifier prefix, this cause an error in Webstorm, when you need to pass a few modifiers to one block. 

![image](https://cloud.githubusercontent.com/assets/1586852/15673768/83baddd4-2741-11e6-86b6-0e06d7d221c5.png)

it was ok for us, for long time, because Jade lexer worked with that normally.

But recently we tried to use new [pug-lexer](https://github.com/pugjs/pug-lexer), and this syntax is no more valid.

![image](https://cloud.githubusercontent.com/assets/1586852/15673947/b350402e-2742-11e6-8263-e51a52a8c1c0.png)

So, i add an option (disabled by default, because can broke backward-capability) `few_modifiers_per_class` which allows to write this code

``` jade
+b.block--modifier-name--other-modifier
//instead of this 
+b.block--modifier-name.--other-modifier
```

Also i add some tests, and fix existing tests
